### PR TITLE
fix: git config conditional templating

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,7 +1,7 @@
 {{- if (ne .gpg_signingkey "") -}}
 [commit]
     gpgsign = true
-{{- end -}}
+{{- end }}
 
 
 [core]
@@ -66,8 +66,8 @@
 [user]
   email          = "{{- .email -}}"
   name           = "{{- .name -}}"
-{{- if (ne .gpg_signingkey "") -}}
-  gpg_signingkey = "{{- .gpg_signingkey -}}"
+{{- if (ne .gpg_signingkey "") }}
+  signingkey = "{{- .gpg_signingkey -}}"
 {{- end  }}
   useConfigOnly  = true
 


### PR DESCRIPTION
I pinched your config for my own dotfile repo and found these issues with the templating x

+ fixes template formatting
+ use the correct config name for git singingKey

**Problem**

Before fix
<img width="348" alt="Screenshot 2022-08-27 at 17 23 41" src="https://user-images.githubusercontent.com/15124052/187040884-c8500632-fb21-49df-ab16-e354875ae22e.png">
<img width="515" alt="Screenshot 2022-08-27 at 17 47 53" src="https://user-images.githubusercontent.com/15124052/187040909-f425a828-1776-451a-ad7e-98fed1ac16fe.png">

Post fix
<img width="456" alt="Screenshot 2022-08-27 at 17 27 45" src="https://user-images.githubusercontent.com/15124052/187040893-d8dd7220-6381-42e8-8f3e-4eac0a99bc10.png">
<img width="509" alt="Screenshot 2022-08-27 at 18 14 43" src="https://user-images.githubusercontent.com/15124052/187040911-366769a8-52aa-4bca-8d2e-9afbd49743a8.png">


Signed-off-by: kolvin <15124052+Kolvin@users.noreply.github.com>

